### PR TITLE
Fix for italian command and typo fix (+ issue)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ build the jar file
 mvn clean install
 mvn clean package
 
-inputConf.json: The file contains input parameter for the system
 ```
+inputConf.json: The file contains input parameter for the system
 - languageCode: `en` (English), `de` (German), `it` (Italian)
 - inputDir: The input directory that contains lemon csv files  that will be processed by QueGG. 
 - outputDir: The output directory for the json grammar entry files that are produced by QueGG.
@@ -66,8 +66,8 @@ java -jar target/QuestionGrammarGenerator.jar inputConf_de.json dataset/dbpedia_
 spanish
 java -jar target/QuestionGrammarGenerator.jar inputConf_es.json dataset/dbpedia_es.json        
 
-italain
-java -jar target/QuestionGrammarGenerator.jar inputConf_it.json dataset/dbpedia_it.json  
+italian
+java -jar target/QuestionGrammarGenerator.jar inputConf_it.json dataset/beniculturali.json  
 
 english and dbpedia
 java -jar target/QuestionGrammarGenerator.jar inputConf_en.json dataset/dbpedia_en.json 


### PR DESCRIPTION
I know this isn't the right procedure, but since there is not an issue tab it's the only way I can ask for help since I need to test this system for a project.
If I try to use the command for italian (with the argument dataset/beniculturali.json intead of dataset/dbpedia_it.json since there is no such file in the dataset folder) it will show the following messages during the build:

```
[main] DEBUG org.apache.jena.util.LocationMapper - Failed to find configuration: file:location-mapping.rdf;file:location-mapping.n3;file:location-mapping.ttl;file:etc/location-mapping.rdf;file:etc/location-mapping.n3;file:etc/location-mapping.ttl`

[main] DEBUG org.apache.jena.riot.system.stream.JenaIOEnvironment - Failed to find configuration: location-mapping.ttl;location-mapping.rdf;location-mapping.n3;etc/location-mapping.rdf;etc/location-mapping.n3;etc/location-mapping.ttl
```

and then it will fail with

```
GRAVE: null
java.lang.Exception: invalid entry.No grammar entry is found!!!!
	at turtle.TurtleCreation.findSyntacticFrame(TurtleCreation.java:86)
	at turtle.TurtleCreation.findSyntacticFrame(TurtleCreation.java:58)
	at turtle.ItalianTurtle.setSyntacticFrame(ItalianTurtle.java:98)
	at turtle.ItalianTurtle.generateTurtle(ItalianTurtle.java:79)
	at turtle.ItalianTurtle.<init>(ItalianTurtle.java:40)
	at QueGG.csvToProto(QueGG.java:199)
	at QueGG.main(QueGG.java:83)

Exception in thread "main" java.lang.Exception: invalid entry.No grammar entry is found!!!!
	at turtle.ItalianTurtle.generateTurtle(ItalianTurtle.java:89)
	at turtle.ItalianTurtle.<init>(ItalianTurtle.java:40)
	at QueGG.csvToProto(QueGG.java:199)
	at QueGG.main(QueGG.java:83)
```

If possible I would like to know if I'm doing anything wrong, I just followed the guide on the readme.
Update: none of the other languages work, they give this error with both Netbeans 15 and WSL:

```
Exception in thread "main" java.lang.RuntimeException: java.lang.RuntimeException: invalid line:
        at net.lexinfo.LexInfo.<init>(LexInfo.java:116)
        at eu.monnetproject.lemon.impl.LemonSerializerImpl.<init>(LemonSerializerImpl.java:60)
        at eu.monnetproject.lemon.LemonSerializer.newInstance(LemonSerializer.java:290)
        at lexicon.LexiconImporter.loadModelFromDir(LexiconImporter.java:33)
        at QueGG.loadInputAndGenerate(QueGG.java:268)
        at QueGG.init(QueGG.java:255)
        at QueGG.turtleToProto(QueGG.java:208)
        at QueGG.main(QueGG.java:84)
Caused by: java.lang.RuntimeException: invalid line:
        at net.lexinfo.LexInfo.readMap(LexInfo.java:131)
        at net.lexinfo.LexInfo.<init>(LexInfo.java:100)
        ... 7 more
```